### PR TITLE
Fix slf4j-reload4j scope: change from compile to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>2.0.9</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
slf4j-reload4j was added in v3.3.0 as a replacement for slf4j-log4j12, but without <scope>test</scope>. The previous slf4j-log4j12 had test scope.

Without test scope, slf4j-reload4j becomes a compile dependency which transitively pulls in reload4j and its dependency tree into consumers. In OSGi environments, this causes the bnd resolver to hang indefinitely due to split-package conflicts between reload4j and pax-logging-api (both export org.apache.log4j).

This matches the intent: j2mod only needs a logging backend for tests, not at runtime

SHOULD fix:
https://github.com/OpenEMS/openems/actions/runs/23319012647/job/67825717669?pr=3624
and:
https://community.openems.io/t/cannot-connect-the-ui-to-openems-edge/10786/3?u=sn0w3y